### PR TITLE
added julia recipe

### DIFF
--- a/julia/container.yaml
+++ b/julia/container.yaml
@@ -8,6 +8,5 @@ tags:
   1.8.3: sha256:11eeb3baa4c867ecd422bdeab5f3d44a66161ed963c349f59eacb656ecf3a034
 filter:
 - "^[0-9]+[.][0-9]+[.][0-9]+$"
-- "^[0-9]+[.][0-9]+$"
 aliases:
   julia: /usr/local/julia/bin/julia

--- a/julia/container.yaml
+++ b/julia/container.yaml
@@ -6,5 +6,8 @@ latest:
   1.8.3: sha256:11eeb3baa4c867ecd422bdeab5f3d44a66161ed963c349f59eacb656ecf3a034
 tags:
   1.8.3: sha256:11eeb3baa4c867ecd422bdeab5f3d44a66161ed963c349f59eacb656ecf3a034
+filter:
+- "^[0-9]+[.][0-9]+[.][0-9]+$"
+- "^[0-9]+[.][0-9]+$"
 aliases:
   julia: /usr/local/julia/bin/julia

--- a/julia/container.yaml
+++ b/julia/container.yaml
@@ -1,4 +1,4 @@
-docker: python
+docker: julia
 url: https://hub.docker.com/_/julia
 maintainer: '@marcodelapierre'
 description: An interpreted, high-level, high-performance dynamic programming language for technical computing.

--- a/julia/container.yaml
+++ b/julia/container.yaml
@@ -1,0 +1,10 @@
+docker: python
+url: https://hub.docker.com/_/julia
+maintainer: '@marcodelapierre'
+description: An interpreted, high-level, high-performance dynamic programming language for technical computing.
+latest:
+  1.8.3: sha256:11eeb3baa4c867ecd422bdeab5f3d44a66161ed963c349f59eacb656ecf3a034
+tags:
+  1.8.3: sha256:11eeb3baa4c867ecd422bdeab5f3d44a66161ed963c349f59eacb656ecf3a034
+aliases:
+  julia: /usr/local/julia/bin/julia


### PR DESCRIPTION
Adding recipe for official Julia language container.

Two important notes:
1- I think we need to add a filter to just get version tags such as `1.8.3` and so on, WITHOUT any special OS suffixes (`-buster` and so on). @vsoch could you help me?
2- I have noted this is a multi arch repo. I have manually added the digest for the `amd64`, but I was wondering how the registry deals with multi-arch for the automatic updates..?
