### PR TITLE
Adds recipes for AMD InfinityHub containers

### DIFF
--- a/amd/infinityhub/cp2k/container.yaml
+++ b/amd/infinityhub/cp2k/container.yaml
@@ -1,0 +1,35 @@
+docker: amdih/cp2k
+url: https://www.amd.com/en/technologies/infinity-hub/cp2k
+description: CP2K is a quantum chemistry and solid state physics software package that can perform atomistic simulations of solid state, liquid, molecular, periodic, material, crystal, and biological systems. 
+maintainer: "@cristiandipietrantonio"
+latest:
+  '8.2': sha256:5947603de32c4e690f734075f7625563a2de18d1c3276ec10fceccdb332022ec
+tags:
+  '8.2': sha256:5947603de32c4e690f734075f7625563a2de18d1c3276ec10fceccdb332022ec
+aliases:
+- name: cp2k.popt  
+  command: cp2k.popt  
+- name: cp2k.psmp.dbcsr_gpu
+  command: cp2k.psmp.dbcsr_gpu
+- name: cp2k_shell.psmp
+  command: cp2k_shell.psmp
+- name: graph.psmp	      
+  command: graph.psmp	      
+- name: grid_unittest.psmp
+  command: grid_unittest.psmp
+- name: memory_utilities_unittest.psmp
+  command: memory_utilities_unittest.psmp
+- name: xyz2dcd.psmp
+  command: xyz2dcd.psmp
+- name: cp2k.psmp
+  command: cp2k.psmp
+- name: cp2k.psmp.no_dbcsr_gpu
+  command: cp2k.psmp.no_dbcsr_gpu
+- name: dumpdcd.psmp
+  command: dumpdcd.psmp
+- name: grid_miniapp.psmp
+  command: grid_miniapp.psmp
+- name: libcp2k_unittest.psmp  
+  command: libcp2k_unittest.psmp  
+- name: parallel_rng_types_unittest.psmp
+  command: parallel_rng_types_unittest.psmp

--- a/amd/infinityhub/gromacs/container.yaml
+++ b/amd/infinityhub/gromacs/container.yaml
@@ -1,0 +1,11 @@
+docker: amdih/gromacs
+url: https://www.amd.com/en/technologies/infinity-hub/gromacs
+description: GROMACS is a versatile package to perform molecular dynamics, i.e. simulate the Newtonian equations of motion for systems with hundreds to millions of particles. 
+maintainer: "@cristiandipietrantonio"
+latest:
+  '2022.3.amd1_174': sha256:3def3e37a32b014a80620e588f16241e23d4043b6a0a022f09a3d856cda72ee3
+tags:
+  '2022.3.amd1_174': sha256:3def3e37a32b014a80620e588f16241e23d4043b6a0a022f09a3d856cda72ee3
+aliases:
+- name: gmx
+  command: gmx

--- a/amd/infinityhub/lammps/container.yaml
+++ b/amd/infinityhub/lammps/container.yaml
@@ -1,0 +1,13 @@
+docker: amdih/lammps
+url: https://www.amd.com/en/technologies/infinity-hub/lammps
+description: LAMMPS is a classical molecular dynamics code with a focus on materials modeling. It's an acronym for Large-scale Atomic/Molecular Massively Parallel Simulator.
+maintainer: "@cristiandipietrantonio"
+latest:
+  '2022.5.04_130': sha256:d885a385d8d8c54e1ed82a6ca601f3f5db0781aa2439c01879998984e9e85b69
+tags:
+  '2022.5.04_130': sha256:d885a385d8d8c54e1ed82a6ca601f3f5db0781aa2439c01879998984e9e85b69
+  '2021.5.14_121': sha256:9479772560d24d31ef8f006e558a8a57b67ee1034776b061be5200cf3d92d9d6
+aliases:
+- name: lmp 
+  command: lmp 
+

--- a/amd/infinityhub/namd/container.yaml
+++ b/amd/infinityhub/namd/container.yaml
@@ -1,0 +1,15 @@
+docker: amdih/namd
+url: https://www.amd.com/en/technologies/infinity-hub/namd 
+description: NAMD is a molecular dynamics package designed for simulating the movement of biomolecules over time. 
+maintainer: "@cristiandipietrantonio"
+latest:
+  '2.15a2-20211101':sha256:b85122abb64ed3db9ee2981eadb88ef6262eaa7f116cdadbe7f35df12be4f3c0
+tags:
+  '2.15a2-20211101':sha256:b85122abb64ed3db9ee2981eadb88ef6262eaa7f116cdadbe7f35df12be4f3c0
+  '2.15a2': sha256:f516c3a214bdcbabbf8d0302872ecf4f9904a3a99415f2ee597c1a02721366d6
+aliases:
+- name: charmrun  
+  command: charmrun
+- name: namd2
+  command: namd2
+

--- a/amd/infinityhub/namd3/container.yaml
+++ b/amd/infinityhub/namd3/container.yaml
@@ -1,0 +1,14 @@
+docker: amdih/namd3
+url: https://www.amd.com/en/technologies/infinity-hub/namd 
+description: NAMD is a molecular dynamics package designed for simulating the movement of biomolecules over time. 
+maintainer: "@cristiandipietrantonio"
+latest:
+  '3.0a9': sha256:d6fcadbfb948b2e92285cd12ce8e06c184c370a370fdc6aec52e3099da64d66b 
+tags:
+  '3.0a9': sha256:d6fcadbfb948b2e92285cd12ce8e06c184c370a370fdc6aec52e3099da64d66b 
+aliases:
+- name: charmrun  
+  command: charmrun
+- name: namd3
+  command: namd3
+


### PR DESCRIPTION
Hi there!

This pull request adds recipes for GPU-accelerated applications: cp2k, gromacs, namd, namd3, lammps.

We use these containers at Pawsey to support GPU computations on Setonix.