### PR TITLE
Add alias to plink container.yml

### DIFF
--- a/quay.io/biocontainers/plink/container.yaml
+++ b/quay.io/biocontainers/plink/container.yaml
@@ -9,3 +9,5 @@ tags:
   1.90b6.21--hec16e2b_4: sha256:bdccab437af505633bf1bc259e587493585b1899d055dc78a5db66aac3c2c2fa
   1.90b6.21--h031d066_5: sha256:2029eac3d7d29d6acc5555c07d7605af4742dfab245eea0d0d2d8eca8483e653
 docker: quay.io/biocontainers/plink
+aliases:
+  plink: /usr/local/bin/plink


### PR DESCRIPTION
Plink biocontainer can't be executed as alias was missing. Added alias for execution.  